### PR TITLE
fix: Make dev script platform-agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "nodemon --exec \"npx tsx server.ts\" --watch server.ts --watch src --ext ts,tsx,js,jsx 2>&1 | tee dev.log",
+    "dev": "nodemon --exec \"npx tsx server.ts\" --watch server.ts --watch src --ext ts,tsx,js,jsx",
     "build": "next build",
     "start": "NODE_ENV=production tsx server.ts 2>&1 | tee server.log",
     "lint": "next lint",


### PR DESCRIPTION
- Removes the `| tee dev.log` command from the `dev` script in `package.json`.
- This change ensures the script can run on Windows environments where `tee` is not available by default.
- The primary functionality of the `dev` script is preserved.