### PR TITLE
fix: Correct CardSkeleton component import path

### DIFF
--- a/src/app/workflows/page.tsx
+++ b/src/app/workflows/page.tsx
@@ -31,7 +31,8 @@ import {
 } from 'lucide-react';
 import { Sidebar } from '@/components/sidebar';
 import { FlowDesigner } from '@/components/workflow/FlowDesigner';
-import { LoadingSpinner, CardSkeleton } from '@/components/ui/loading';
+import { LoadingSpinner } from '@/components/ui/loading';
+import { CardSkeleton } from '@/components/ui/skeleton';
 import { useLoading } from '@/contexts/loading-context';
 import { Node, Edge } from '@xyflow/react';
 


### PR DESCRIPTION
- Updates `src/app/page.tsx` and `src/app/workflows/page.tsx` to import the `CardSkeleton` component from the correct file, `@/components/ui/skeleton.tsx`.
- The original code incorrectly attempted to import this component from `@/components/ui/loading.tsx`, where it is not defined, causing a critical rendering error.