### PR TITLE
fix: Add postinstall script to run prisma generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "nodemon --exec \"npx tsx server.ts\" --watch server.ts --watch src --ext ts,tsx,js,jsx",
+    "postinstall": "prisma generate",
     "build": "next build",
     "start": "NODE_ENV=production tsx server.ts 2>&1 | tee server.log",
     "lint": "next lint",


### PR DESCRIPTION
- Adds a `postinstall` script to `package.json` that automatically runs `prisma generate`.
- This resolves a critical error where the Prisma client would not be initialized after a fresh installation or after changing the database provider.
- This ensures the application can connect to the database and run correctly without requiring a manual `prisma generate` command.